### PR TITLE
Fix Asset Publishing

### DIFF
--- a/src/ModuleInstaller.php
+++ b/src/ModuleInstaller.php
@@ -14,12 +14,18 @@ class ModuleInstaller implements InstallerContract
     {
         Artisan::call(
             command: "vendor:publish",
-            parameters:['--tag'=>'erp-crm-migrations']
+            parameters: [
+                '--tag' => 'erp-crm-migrations',
+                '--provider' => 'JustSteveKing\Laravel\ERP\CRM\CRMServiceProvider'
+            ]
         );
 
         Artisan::call(
             command: "vendor:publish",
-            parameters:['--tag'=>'erp-crm-config']
+            parameters: [
+                '--tag' => 'erp-crm-config',
+                '--provider' => 'JustSteveKing\Laravel\ERP\CRM\CRMServiceProvider'
+            ]
         );
         
         Log::info(

--- a/src/ModuleInstaller.php
+++ b/src/ModuleInstaller.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JustSteveKing\Laravel\ERP\CRM;
 
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Log;
 use JustSteveKing\Laravel\ERPContracts\Module\InstallerContract;
 
@@ -11,6 +12,16 @@ class ModuleInstaller implements InstallerContract
 {
     public function install(): void
     {
+        Artisan::call(
+            command: "vendor:publish",
+            parameters:['--tag'=>'erp-crm-migrations']
+        );
+
+        Artisan::call(
+            command: "vendor:publish",
+            parameters:['--tag'=>'erp-crm-config']
+        );
+        
         Log::info(
             message: 'Installing module juststeveking/laravel-erp-crm',
         );


### PR DESCRIPTION
This PR fixes publishing of migrations and config file.
Borrowed from [laravel/jetsream](https://github.com/laravel/jetstream/blob/8cc54788c657142053a2e6becb4e406109830f8a/src/Console/InstallCommand.php#L37) who I know publishes a couple of assets when you run artisan jetstream:install. I note that Laravel team adds a --force=true flag but I was able to get it to run without the said flag.
Kudos @JustSteveKing for your great work; learnt a lot of tricks from you.